### PR TITLE
[codex] Align orchestration with package-owned seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ This package centers on reproducible experiment structure and execution:
 - canonical artifact exports (`study.yaml`, `manifest.json`, `conditions.csv`,
   `runs.csv`, `events.csv`, `evaluations.csv`, and machine-readable hypothesis/plan files)
 - documented artifact contracts that downstream analysis can ingest directory-first
-- thin adapters that connect to the public APIs of sibling agent/problem/analysis libraries
+- thin orchestration adapters that delegate sibling-package interoperability to
+  `design_research_problems.integration`, `design_research_agents.integration`,
+  and `design_research_analysis.integration`
+
+`design-research-experiments` itself is the orchestration surface. There is
+intentionally no separate `design_research_experiments.integration` module.
 
 ## Quickstart
 

--- a/docs/examples/core/real_stack_interoperability.rst
+++ b/docs/examples/core/real_stack_interoperability.rst
@@ -13,7 +13,8 @@ contract with `design-research-analysis`'s artifact-first integration API.
 Technical Implementation
 ------------------------
 
-1. Bootstrap sibling `src/` directories from the local workspace when present.
+1. Import the package-owned ``integration`` modules from installed sibling
+   libraries.
 2. Execute a one-run study that uses a packaged optimization problem together
    with `SeededRandomBaselineAgent`.
 3. Export canonical artifacts and validate the event table through the analysis
@@ -32,6 +33,9 @@ Expected Results
 .. code-block:: bash
 
    PYTHONPATH=src python examples/real_stack_interoperability.py
+
+Install the coordinated sibling packages first. This example now uses the
+public package-owned seams directly and no longer bootstraps adjacent worktrees.
 
 The script prints the packaged problem identity, one successful run result, and
 the exported artifact filenames after the event table passes validation.

--- a/docs/examples/core/real_stack_interoperability.rst
+++ b/docs/examples/core/real_stack_interoperability.rst
@@ -13,8 +13,7 @@ contract with `design-research-analysis`'s artifact-first integration API.
 Technical Implementation
 ------------------------
 
-1. Import the package-owned ``integration`` modules from installed sibling
-   libraries.
+1. Import the package-owned `integration` modules from installed sibling libraries.
 2. Execute a one-run study that uses a packaged optimization problem together
    with `SeededRandomBaselineAgent`.
 3. Export canonical artifacts and validate the event table through the analysis
@@ -33,9 +32,6 @@ Expected Results
 .. code-block:: bash
 
    PYTHONPATH=src python examples/real_stack_interoperability.py
-
-Install the coordinated sibling packages first. This example now uses the
-public package-owned seams directly and no longer bootstraps adjacent worktrees.
 
 The script prints the packaged problem identity, one successful run result, and
 the exported artifact filenames after the event table passes validation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,10 @@ Highlights
 - Artifact contracts that connect runs, events, and evaluation outputs
 - Reproducible condition materialization and execution helpers
 - Runnable examples and recipes for study-definition workflows
-- Integration points that wire agents, problems, and downstream analysis together
+- Orchestration adapters that delegate sibling-package seams to
+  ``design_research_problems.integration``,
+  ``design_research_agents.integration``, and
+  ``design_research_analysis.integration``
 
 Typical Workflow
 ----------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,12 @@ Maintainer Shortcut
 Notes
 -----
 
-The experiments package keeps runtime dependencies deliberately small and relies
-on adapters for optional integration with sibling libraries. See
-:doc:`dependencies_and_extras` for development extras and release-check
-guidance.
+ The experiments package keeps runtime dependencies deliberately small and
+ delegates optional sibling interoperability to
+ ``design_research_problems.integration``,
+ ``design_research_agents.integration``, and
+ ``design_research_analysis.integration``. The package itself remains the
+ orchestration surface; there is intentionally no separate
+ ``design_research_experiments.integration`` module. See
+ :doc:`dependencies_and_extras` for development extras and release-check
+ guidance.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -25,7 +25,8 @@ Primary modules and responsibilities:
 - ``design_research_experiments.runners``: execution orchestration, resume, checkpoint flow.
 - ``design_research_experiments.artifacts``: canonical exports, manifests, and bundling.
 - ``design_research_experiments.recipes``: reusable function-based study templates.
-- ``design_research_experiments.adapters``: integration glue for agents/problems/analysis.
+- ``design_research_experiments.adapters``: thin orchestration glue that delegates
+  sibling-package interoperability to owner-owned ``integration`` modules.
 - ``design_research_experiments.io``: YAML/JSON/CSV/SQLite persistence helpers.
 
 .. toctree::

--- a/examples/real_stack_interoperability.py
+++ b/examples/real_stack_interoperability.py
@@ -6,7 +6,7 @@ Run one packaged problem from `design-research-problems` through a public
 contract with `design-research-analysis`'s artifact-first integration API.
 
 ## Technical Implementation
-1. Bootstrap sibling `src/` directories from the local workspace when present.
+1. Import the package-owned `integration` modules from installed sibling libraries.
 2. Execute a one-run study that uses a packaged optimization problem together
    with `SeededRandomBaselineAgent`.
 3. Export canonical artifacts and validate the event table through the analysis
@@ -20,32 +20,17 @@ the exported artifact filenames after the event table passes validation.
 from __future__ import annotations
 
 import importlib
-import sys
 from pathlib import Path
 
 import design_research_experiments as drex
 
 
-def _bootstrap_sibling_sources() -> None:
-    """Add sibling package `src/` directories when the repos are checked out locally."""
-    workspace_root = Path(__file__).resolve().parents[2]
-    for repo_name in (
-        "design-research-problems",
-        "design-research-agents",
-        "design-research-analysis",
-    ):
-        src_path = workspace_root / repo_name / "src"
-        src_path_text = str(src_path)
-        if src_path.exists() and src_path_text not in sys.path:
-            sys.path.insert(0, src_path_text)
-
-
 def _load_stack_modules() -> dict[str, object] | None:
-    """Import sibling stack packages when available from the local workspace."""
-    _bootstrap_sibling_sources()
+    """Import sibling stack packages when the coordinated libraries are installed."""
     try:
         problems_module = importlib.import_module("design_research_problems")
-        importlib.import_module("design_research_agents")
+        problems_integration = importlib.import_module("design_research_problems.integration")
+        agents_integration = importlib.import_module("design_research_agents.integration")
     except ImportError as exc:
         print(f"Real stack example skipped: {exc}")
         return None
@@ -59,6 +44,8 @@ def _load_stack_modules() -> dict[str, object] | None:
 
     return {
         "problems": problems_module,
+        "problems_integration": problems_integration,
+        "agents_integration": agents_integration,
         "analysis": analysis_module,
         "analysis_integration": analysis_integration,
     }
@@ -70,12 +57,13 @@ def main() -> None:
     if modules is None:
         return
 
-    problems_module = modules["problems"]
+    problems_integration = modules["problems_integration"]
+    agents_integration = modules["agents_integration"]
     analysis_module = modules["analysis"]
     analysis_integration = modules["analysis_integration"]
     problem_id = "gmpb_default_dynamic_min"
-    packaged_problem = problems_module.get_problem(problem_id)
-    problem_packet = drex.resolve_problem(problem_id)
+    problem_binding = problems_integration.resolve_problem_binding(problem_id)
+    packaged_problem = problem_binding.problem_object
 
     study = drex.Study(
         study_id="real-stack-interoperability",
@@ -100,7 +88,6 @@ def main() -> None:
     run_results = drex.run_study(
         study,
         conditions=conditions,
-        problem_registry={problem_id: problem_packet},
         show_progress=False,
     )
     exported_paths = drex.export_analysis_tables(
@@ -123,6 +110,8 @@ def main() -> None:
 
     print("Problem ID:", packaged_problem.metadata.problem_id)
     print("Problem family:", packaged_problem.metadata.kind.value)
+    print("Problem integration:", problems_integration.__name__)
+    print("Agent integration:", agents_integration.__name__)
     print("Agent:", study.agent_specs[0])
     print("Completed runs:", len(run_results))
     print("Run status:", run_result.status.value)

--- a/src/design_research_experiments/adapters/agents.py
+++ b/src/design_research_experiments/adapters/agents.py
@@ -74,7 +74,9 @@ def execute_agent(
     agent_bindings: Mapping[str, AgentBinding] | None = None,
 ) -> AgentExecution:
     """Execute one agent run and normalize outputs, events, and trace refs."""
-    if isinstance(agent_spec_ref, str) and not (agent_bindings and agent_spec_ref in agent_bindings):
+    if isinstance(agent_spec_ref, str) and not (
+        agent_bindings and agent_spec_ref in agent_bindings
+    ):
         owner_integration = _load_agents_integration_module()
         if owner_integration is None:
             raise ValidationError(

--- a/src/design_research_experiments/adapters/agents.py
+++ b/src/design_research_experiments/adapters/agents.py
@@ -1,4 +1,4 @@
-"""Agent-layer adapter utilities built on public agent APIs."""
+"""Agent-layer adapter utilities built on package-owned and explicit agent APIs."""
 
 from __future__ import annotations
 
@@ -74,6 +74,22 @@ def execute_agent(
     agent_bindings: Mapping[str, AgentBinding] | None = None,
 ) -> AgentExecution:
     """Execute one agent run and normalize outputs, events, and trace refs."""
+    if isinstance(agent_spec_ref, str) and not (agent_bindings and agent_spec_ref in agent_bindings):
+        owner_integration = _load_agents_integration_module()
+        if owner_integration is None:
+            raise ValidationError(
+                "String agent references now require `design_research_agents.integration`. "
+                "Install the coordinated monthly release or use an explicit binding/object."
+            )
+        return _execute_via_owner_integration(
+            owner_integration=owner_integration,
+            agent_spec_ref=agent_spec_ref,
+            run_spec=run_spec,
+            condition=condition,
+            problem_packet=problem_packet,
+            agent_bindings=agent_bindings,
+        )
+
     executable = resolve_agent(
         agent_spec_ref,
         condition=condition,
@@ -86,6 +102,60 @@ def execute_agent(
         problem_packet=problem_packet,
     )
     return _normalize_agent_execution(raw=raw, run_spec=run_spec, condition=condition)
+
+
+def _execute_via_owner_integration(
+    *,
+    owner_integration: Any,
+    agent_spec_ref: str,
+    run_spec: RunSpec,
+    condition: Condition,
+    problem_packet: ProblemPacket,
+    agent_bindings: Mapping[str, AgentBinding] | None = None,
+) -> AgentExecution:
+    """Execute one string agent reference through the package-owned integration surface."""
+    problem_object = _problem_object_from_packet(problem_packet)
+    dependencies = _build_agent_dependencies(
+        problem_packet=problem_packet,
+        problem_object=problem_object,
+        run_spec=run_spec,
+        condition=condition,
+    )
+    prompt_input = _select_agent_prompt_input(problem_packet, problem_object=problem_object)
+    envelope = owner_integration.execute_agent_run(
+        agent_spec_ref,
+        prompt=prompt_input,
+        request_id=run_spec.run_id,
+        dependencies=dependencies,
+        agent_bindings=agent_bindings,
+    )
+    return AgentExecution(
+        output=dict(getattr(envelope, "output", {})),
+        metrics=dict(getattr(envelope, "metrics", {})),
+        events=_normalize_events(
+            raw_events=getattr(envelope, "events", []),
+            run_spec=run_spec,
+            condition=condition,
+            output=dict(getattr(envelope, "output", {})),
+        ),
+        trace_refs=list(getattr(envelope, "trace_refs", [])),
+        metadata=dict(getattr(envelope, "metadata", {})),
+    )
+
+
+def _load_agents_integration_module() -> Any | None:
+    """Return the packaged agent-integration module when available."""
+    try:
+        return importlib.import_module("design_research_agents.integration")
+    except ImportError as exc:
+        try:
+            importlib.import_module("design_research_agents")
+        except ImportError:
+            return None
+        raise ValidationError(
+            "design-research-agents is installed but does not expose the package-owned "
+            "`integration` module. Upgrade to the coordinated monthly release."
+        ) from exc
 
 
 def _materialize_agent_binding(binding: AgentBinding, condition: Condition) -> Any:

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -1,4 +1,4 @@
-"""Problem-layer adapter utilities built on public problem APIs."""
+"""Problem-layer adapter utilities for orchestration-owned packet handling."""
 
 from __future__ import annotations
 
@@ -32,36 +32,28 @@ def resolve_problem(
     if isinstance(problem_spec_ref, ProblemPacket):
         return problem_spec_ref
 
-    if isinstance(problem_spec_ref, str):
-        if registry and problem_spec_ref in registry:
-            return registry[problem_spec_ref]
-
-        packet = _resolve_from_design_research_problems(problem_spec_ref)
-        if packet is not None:
-            return packet
-
-        return ProblemPacket(
-            problem_id=problem_spec_ref,
-            family="unknown",
-            brief=problem_spec_ref,
-            payload={"problem_id": problem_spec_ref},
-            metadata={},
-        )
+    if isinstance(problem_spec_ref, str) and registry and problem_spec_ref in registry:
+        return _packet_from_registry_entry(registry[problem_spec_ref])
 
     if isinstance(problem_spec_ref, Mapping):
-        return ProblemPacket(
-            problem_id=str(problem_spec_ref.get("problem_id", "problem")),
-            family=str(problem_spec_ref.get("family", "unknown")),
-            brief=str(problem_spec_ref.get("brief", "")),
-            payload=dict(cast(Mapping[str, Any], problem_spec_ref.get("payload", {}))),
-            metadata=dict(cast(Mapping[str, Any], problem_spec_ref.get("metadata", {}))),
-            evaluator=cast(
-                Callable[[Mapping[str, Any]], Any] | None,
-                problem_spec_ref.get("evaluator"),
-            ),
-        )
+        return _packet_from_mapping(problem_spec_ref)
 
-    return _packet_from_object(problem_spec_ref)
+    if isinstance(problem_spec_ref, str):
+        owner_integration = _load_problems_integration_module()
+        if owner_integration is None:
+            raise ValidationError(
+                "String problem references now require `design_research_problems.integration`. "
+                "Install the coordinated monthly release or pass an explicit `ProblemPacket` "
+                "through `problem_registry`."
+            )
+        binding = owner_integration.resolve_problem_binding(problem_spec_ref)
+        return _packet_from_problem_binding(binding, owner_integration=owner_integration)
+
+    raise ValidationError(
+        "Standalone design-research-experiments accepts only `ProblemPacket` instances, "
+        "explicit packet mappings, or string problem ids resolved through "
+        "`design_research_problems.integration`."
+    )
 
 
 def evaluate_problem(
@@ -120,132 +112,66 @@ def sample_problem_packets(
     return sampled
 
 
-def _resolve_from_design_research_problems(problem_id: str) -> ProblemPacket | None:
-    """Attempt resolving from the upstream design-research-problems package."""
-    try:
-        module = importlib.import_module("design_research_problems")
-        get_problem = getattr(module, "get_problem", None)
-    except Exception:
-        return None
+def _packet_from_registry_entry(problem_ref: Any) -> ProblemPacket:
+    """Resolve one explicit registry entry into a packet."""
+    if isinstance(problem_ref, ProblemPacket):
+        return problem_ref
+    if isinstance(problem_ref, Mapping):
+        return _packet_from_mapping(problem_ref)
 
-    if not callable(get_problem):
-        return None
-
-    try:
-        problem_obj = get_problem(problem_id)
-    except Exception:
-        return None
-
-    return _packet_from_object(problem_obj, fallback_problem_id=problem_id)
-
-
-def _packet_from_object(problem_obj: Any, fallback_problem_id: str | None = None) -> ProblemPacket:
-    """Normalize an arbitrary problem-like object into a `ProblemPacket`."""
-    metadata_object = getattr(problem_obj, "metadata", None)
-    problem_id = _stringify_first(
-        getattr(metadata_object, "problem_id", None),
-        getattr(problem_obj, "problem_id", None),
-        fallback_problem_id,
-        "problem",
-    )
-    family = _stringify_first(
-        _value_or_enum(getattr(metadata_object, "kind", None)),
-        getattr(problem_obj, "family", None),
-        problem_obj.__class__.__name__,
+    raise ValidationError(
+        "Problem registries now require `ProblemPacket` values or explicit packet "
+        "mappings. Resolve packaged sibling problems by string id through "
+        "`design_research_problems.integration`."
     )
 
-    brief = _resolve_problem_brief(problem_obj, fallback=problem_id)
 
-    evaluator = getattr(problem_obj, "evaluate", None)
-    if evaluator is not None and not callable(evaluator):
-        raise ValidationError("Problem evaluator must be callable when present.")
-
-    payload = {
-        "problem_object": problem_obj,
-    }
-
-    metadata = {
-        "problem_class": problem_obj.__class__.__name__,
-    }
-    metadata.update(_extract_problem_metadata(problem_obj))
-
+def _packet_from_mapping(problem_spec_ref: Mapping[str, Any]) -> ProblemPacket:
+    """Build one packet from an explicit mapping payload."""
     return ProblemPacket(
-        problem_id=problem_id,
-        family=family,
-        brief=brief,
-        payload=payload,
-        metadata=metadata,
-        evaluator=cast(Callable[[Mapping[str, Any]], Any] | None, evaluator),
+        problem_id=str(problem_spec_ref.get("problem_id", "problem")),
+        family=str(problem_spec_ref.get("family", "unknown")),
+        brief=str(problem_spec_ref.get("brief", "")),
+        payload=dict(cast(Mapping[str, Any], problem_spec_ref.get("payload", {}))),
+        metadata=dict(cast(Mapping[str, Any], problem_spec_ref.get("metadata", {}))),
+        evaluator=cast(
+            Callable[[Mapping[str, Any]], Any] | None,
+            problem_spec_ref.get("evaluator"),
+        ),
     )
 
 
-def _resolve_problem_brief(problem_obj: Any, *, fallback: str) -> str:
-    """Resolve the richest available human-readable brief for a problem object."""
-    render_brief = getattr(problem_obj, "render_brief", None)
-    if callable(render_brief):
+def _packet_from_problem_binding(binding: Any, *, owner_integration: Any) -> ProblemPacket:
+    """Convert one owner-owned `ProblemBinding` into the experiments packet shape."""
+    return ProblemPacket(
+        problem_id=str(binding.problem_id),
+        family=str(binding.family),
+        brief=str(binding.brief),
+        payload={"problem_object": binding.problem_object},
+        metadata=dict(binding.metadata),
+        evaluator=lambda run_output, current_binding=binding: owner_integration.evaluate_problem_output(
+            current_binding,
+            run_output,
+        ),
+    )
+
+
+def _load_problems_integration_module() -> Any | None:
+    """Return the packaged problem-integration module when available."""
+    try:
+        return importlib.import_module("design_research_problems.integration")
+    except ImportError as exc:
         try:
-            rendered = render_brief()
-        except TypeError:
-            rendered = None
-        except Exception:
-            rendered = None
-        normalized = _normalize_text(rendered)
-        if normalized is not None:
-            return normalized
-
-    for attribute_name in ("statement_markdown", "brief", "prompt"):
-        normalized = _normalize_text(getattr(problem_obj, attribute_name, None))
-        if normalized is not None:
-            return normalized
-
-    metadata_object = getattr(problem_obj, "metadata", None)
-    normalized_summary = _normalize_text(getattr(metadata_object, "summary", None))
-    if normalized_summary is not None:
-        return normalized_summary
-    normalized_title = _normalize_text(getattr(metadata_object, "title", None))
-    if normalized_title is not None:
-        return normalized_title
-    return fallback
+            importlib.import_module("design_research_problems")
+        except ImportError:
+            return None
+        raise ValidationError(
+            "design-research-problems is installed but does not expose the package-owned "
+            "`integration` module. Upgrade to the coordinated monthly release."
+        ) from exc
 
 
-def _extract_problem_metadata(problem_obj: Any) -> dict[str, Any]:
-    """Extract interoperable metadata from a packaged problem-like object."""
-    metadata_object = getattr(problem_obj, "metadata", None)
-    metadata: dict[str, Any] = {}
-
-    title = _normalize_text(getattr(metadata_object, "title", None))
-    if title is not None:
-        metadata["title"] = title
-
-    summary = _normalize_text(getattr(metadata_object, "summary", None))
-    if summary is not None:
-        metadata["summary"] = summary
-
-    problem_kind = _value_or_enum(getattr(metadata_object, "kind", None))
-    normalized_kind = _normalize_text(problem_kind)
-    if normalized_kind is not None:
-        metadata["problem_kind"] = normalized_kind
-
-    capabilities = _string_sequence(getattr(metadata_object, "capabilities", None))
-    if capabilities:
-        metadata["capabilities"] = capabilities
-
-    study_suitability = _string_sequence(getattr(metadata_object, "study_suitability", None))
-    if study_suitability:
-        metadata["study_suitability"] = study_suitability
-
-    feature_flags = _string_sequence(getattr(metadata_object, "feature_flags", None))
-    if feature_flags:
-        metadata["feature_flags"] = feature_flags
-
-    implementation = _normalize_text(getattr(metadata_object, "implementation", None))
-    if implementation is not None:
-        metadata["implementation"] = implementation
-
-    return metadata
-
-
-def _resolve_evaluator_input(packet: ProblemPacket, run_output: Mapping[str, Any]) -> Any:
+def _resolve_evaluator_input(_packet: ProblemPacket, run_output: Mapping[str, Any]) -> Any:
     """Resolve the best evaluator input for packaged and external problem evaluators."""
     preferred_keys = ("candidate", "state", "answer", "solution", "final_answer", "x")
     for key in preferred_keys:
@@ -330,38 +256,6 @@ def _normalize_evaluation_row(row: Mapping[str, Any]) -> dict[str, Any]:
         "aggregation_level": str(row.get("aggregation_level", "run")),
         "notes_json": row.get("notes_json", {}),
     }
-
-
-def _value_or_enum(value: Any) -> Any:
-    """Return an enum's value when present, otherwise the original value."""
-    enum_value = getattr(value, "value", None)
-    if enum_value is not None:
-        return enum_value
-    return value
-
-
-def _stringify_first(*values: Any) -> str:
-    """Return the first non-empty stringified value."""
-    for value in values:
-        normalized = _normalize_text(value)
-        if normalized is not None:
-            return normalized
-    return ""
-
-
-def _string_sequence(value: Any) -> tuple[str, ...]:
-    """Normalize a loose sequence of values to a stable string tuple."""
-    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
-        return ()
-    return tuple(str(item) for item in value if _normalize_text(item) is not None)
-
-
-def _normalize_text(value: Any) -> str | None:
-    """Normalize one optional value to non-empty text."""
-    if value is None:
-        return None
-    normalized = str(value).strip()
-    return normalized or None
 
 
 def _is_metric_scalar(value: Any) -> bool:

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -149,9 +149,11 @@ def _packet_from_problem_binding(binding: Any, *, owner_integration: Any) -> Pro
         brief=str(binding.brief),
         payload={"problem_object": binding.problem_object},
         metadata=dict(binding.metadata),
-        evaluator=lambda run_output, current_binding=binding: owner_integration.evaluate_problem_output(
-            current_binding,
-            run_output,
+        evaluator=lambda run_output, current_binding=binding: (
+            owner_integration.evaluate_problem_output(
+                current_binding,
+                run_output,
+            )
         ),
     )
 

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -143,6 +143,7 @@ def _packet_from_mapping(problem_spec_ref: Mapping[str, Any]) -> ProblemPacket:
 
 def _packet_from_problem_binding(binding: Any, *, owner_integration: Any) -> ProblemPacket:
     """Convert one owner-owned `ProblemBinding` into the experiments packet shape."""
+
     def _evaluate_bound_problem(run_output: Mapping[str, Any]) -> Any:
         return owner_integration.evaluate_problem_output(binding, run_output)
 

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -143,18 +143,16 @@ def _packet_from_mapping(problem_spec_ref: Mapping[str, Any]) -> ProblemPacket:
 
 def _packet_from_problem_binding(binding: Any, *, owner_integration: Any) -> ProblemPacket:
     """Convert one owner-owned `ProblemBinding` into the experiments packet shape."""
+    def _evaluate_bound_problem(run_output: Mapping[str, Any]) -> Any:
+        return owner_integration.evaluate_problem_output(binding, run_output)
+
     return ProblemPacket(
         problem_id=str(binding.problem_id),
         family=str(binding.family),
         brief=str(binding.brief),
         payload={"problem_object": binding.problem_object},
         metadata=dict(binding.metadata),
-        evaluator=lambda run_output, current_binding=binding: (
-            owner_integration.evaluate_problem_output(
-                current_binding,
-                run_output,
-            )
-        ),
+        evaluator=_evaluate_bound_problem,
     )
 
 

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -145,6 +145,7 @@ def _packet_from_problem_binding(binding: Any, *, owner_integration: Any) -> Pro
     """Convert one owner-owned `ProblemBinding` into the experiments packet shape."""
 
     def _evaluate_bound_problem(run_output: Mapping[str, Any]) -> Any:
+        """Route one run output through the owner package evaluator."""
         return owner_integration.evaluate_problem_output(binding, run_output)
 
     return ProblemPacket(

--- a/src/design_research_experiments/reporting.py
+++ b/src/design_research_experiments/reporting.py
@@ -46,14 +46,17 @@ def render_markdown_summary(study: Study, run_results: Sequence[RunResult]) -> s
     return "\n".join(lines)
 
 
-def render_significance_brief(analysis_rows: Sequence[Mapping[str, Any]]) -> str:
+def render_significance_brief(
+    analysis_rows: Sequence[Mapping[str, Any]] | object,
+) -> str:
     """Render a short significance/effect-size brief from analysis outputs."""
+    normalized_rows = _normalize_significance_rows(analysis_rows)
     lines = ["## Significance Brief"]
-    if not analysis_rows:
+    if not normalized_rows:
         lines.append("- No analysis rows provided.")
         return "\n".join(lines)
 
-    for row in analysis_rows:
+    for row in normalized_rows:
         test_name = row.get("test", "test")
         outcome = row.get("outcome", "outcome")
         p_value = row.get("p_value", "n/a")
@@ -107,3 +110,19 @@ def write_markdown_report(output_dir: str | Path, filename: str, content: str) -
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _normalize_significance_rows(
+    analysis_rows: Sequence[Mapping[str, Any]] | object,
+) -> list[Mapping[str, Any]]:
+    """Normalize analysis-report inputs to the row shape used by this renderer."""
+    if isinstance(analysis_rows, Sequence) and not isinstance(analysis_rows, (str, bytes)):
+        return [row for row in analysis_rows if isinstance(row, Mapping)]
+
+    to_rows = getattr(analysis_rows, "to_significance_rows", None)
+    if callable(to_rows):
+        candidate = to_rows()
+        if isinstance(candidate, Sequence) and not isinstance(candidate, (str, bytes)):
+            return [row for row in candidate if isinstance(row, Mapping)]
+
+    return []

--- a/tests/test_adapters_and_reporting.py
+++ b/tests/test_adapters_and_reporting.py
@@ -827,7 +827,9 @@ def test_real_stack_interoperability_contracts(tmp_path: Path) -> None:
     )
 
     problem_id = "gmpb_default_dynamic_min"
-    resolved_problem = problems_module.integration.resolve_problem_binding(problem_id).problem_object
+    resolved_problem = problems_module.integration.resolve_problem_binding(
+        problem_id
+    ).problem_object
     resolved_packet = problem_adapter.resolve_problem(problem_id)
     assert resolved_packet.problem_id == problem_id
     assert resolved_packet.family == resolved_problem.metadata.kind.value

--- a/tests/test_adapters_and_reporting.py
+++ b/tests/test_adapters_and_reporting.py
@@ -216,15 +216,26 @@ def test_problem_adapter_resolution_and_sampling(monkeypatch: pytest.MonkeyPatch
     calls: list[str] = []
 
     def fake_import(name: str) -> Any:
-        """Return a dynamic module for upstream problem resolution."""
-        if name == "design_research_problems":
+        """Return a dynamic module for owner-owned problem integration."""
+        if name == "design_research_problems.integration":
             module = types.SimpleNamespace()
 
-            def get_problem(problem_id: str) -> _FakeProblem:
+            def resolve_problem_binding(problem_id: str) -> Any:
                 calls.append(problem_id)
-                return _FakeProblem(problem_id)
+                problem = _FakeProblem(problem_id)
+                return types.SimpleNamespace(
+                    problem_id=problem.problem_id,
+                    family=problem.family,
+                    brief=problem.brief,
+                    metadata={"problem_class": problem.__class__.__name__},
+                    problem_object=problem,
+                )
 
-            module.get_problem = get_problem
+            def evaluate_problem_output(binding: Any, run_output: dict[str, Any]) -> Any:
+                return binding.problem_object.evaluate(run_output)
+
+            module.resolve_problem_binding = resolve_problem_binding
+            module.evaluate_problem_output = evaluate_problem_output
             return module
         return importlib.import_module(name)
 
@@ -243,59 +254,37 @@ def test_problem_adapter_resolution_and_sampling(monkeypatch: pytest.MonkeyPatch
     assert len(sampled) == 3
 
 
-def test_problem_adapter_object_and_errors() -> None:
-    """Problem adapter should normalize objects and reject invalid evaluators."""
+def test_problem_adapter_standalone_contract_and_evaluation_normalization() -> None:
+    """Standalone experiments should stay explicit while preserving evaluator normalization."""
 
     class WithPrompt:
-        """Problem-like object using prompt fallback."""
+        """Problem-like object that standalone experiments should reject."""
 
         problem_id = "prompt-problem"
         prompt = "prompt text"
         family = "prompt-family"
 
-    normalized = problem_adapter.resolve_problem(WithPrompt())
-    assert normalized.brief == "prompt text"
-    assert problem_adapter.evaluate_problem(normalized, {}) == []
+    with pytest.raises(ValueError, match="Standalone design-research-experiments accepts only"):
+        problem_adapter.resolve_problem(WithPrompt())
 
     packaged_problem = _FakePackagedProblem()
-    packaged_packet = problem_adapter.resolve_problem(packaged_problem)
-    assert packaged_packet.problem_id == "packaged-problem"
-    assert packaged_packet.family == "optimization"
-    assert packaged_packet.brief.startswith("# Packaged Problem")
-    assert packaged_packet.metadata["title"] == "Packaged Problem"
-    assert packaged_packet.metadata["summary"] == "Synthetic packaged benchmark."
-    assert packaged_packet.metadata["problem_kind"] == "optimization"
-    assert packaged_packet.metadata["capabilities"] == (
-        "prompt-packet",
-        "optional-evaluator",
-    )
-    assert packaged_packet.metadata["study_suitability"] == ("intervention-ready",)
-
-    packaged_rows = problem_adapter.evaluate_problem(packaged_packet, {"candidate": [0.25, 0.75]})
-    assert packaged_rows[0]["metric_name"] == "objective_value"
-    assert packaged_rows[0]["metric_value"] == 1.0
-    assert packaged_rows[1]["metric_name"] == "is_feasible"
-    assert packaged_rows[1]["metric_value"] is True
+    with pytest.raises(ValueError, match="Standalone design-research-experiments accepts only"):
+        problem_adapter.resolve_problem(packaged_problem)
 
     @dataclass(frozen=True)
     class _EvaluationWithMappingProxy:
         score: float
         candidate: object
 
-    class MappingProxyEvaluatorProblem:
-        """Problem-like object whose evaluator dataclass includes a mappingproxy field."""
-
-        problem_id = "mappingproxy-problem"
-        family = "decision"
-        brief = "brief"
-
-        def evaluate(self, _candidate: object) -> _EvaluationWithMappingProxy:
-            return _EvaluationWithMappingProxy(
-                score=0.5,
-                candidate=types.MappingProxyType({"x": 1}),
-            )
-
-    mappingproxy_packet = problem_adapter.resolve_problem(MappingProxyEvaluatorProblem())
+    mappingproxy_packet = problem_adapter.ProblemPacket(
+        "mappingproxy-problem",
+        "decision",
+        "brief",
+        evaluator=lambda _candidate: _EvaluationWithMappingProxy(
+            score=0.5,
+            candidate=types.MappingProxyType({"x": 1}),
+        ),
+    )
     mappingproxy_rows = problem_adapter.evaluate_problem(
         mappingproxy_packet,
         {"candidate": {"x": 1}},
@@ -311,16 +300,23 @@ def test_problem_adapter_object_and_errors() -> None:
         }
     ]
 
-    class BadEvaluator:
-        """Problem-like object with non-callable evaluator field."""
 
-        problem_id = "bad"
-        family = "bad"
-        brief = "bad"
-        evaluate = 42
+def test_problem_adapter_raises_clear_error_for_outdated_problem_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """String problem ids should fail clearly when the sibling package lacks `integration`."""
 
-    with pytest.raises(ValueError):
-        problem_adapter.resolve_problem(BadEvaluator())
+    def fake_import(name: str) -> Any:
+        if name == "design_research_problems.integration":
+            raise ImportError("missing integration")
+        if name == "design_research_problems":
+            return types.SimpleNamespace()
+        return importlib.import_module(name)
+
+    monkeypatch.setattr(problem_adapter.importlib, "import_module", fake_import)
+
+    with pytest.raises(ValueError, match="does not expose the package-owned `integration` module"):
+        problem_adapter.resolve_problem("outdated-problem")
 
 
 def test_agent_adapter_execution_paths(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -360,17 +356,53 @@ def test_agent_adapter_execution_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     assert mapping_execution.output["text"] == "raw-text"
 
     def fake_import(name: str) -> Any:
-        """Provide a fake design_research_agents module."""
+        """Provide a fake package-owned agent integration module."""
+        if name == "design_research_agents.integration":
+            module = types.SimpleNamespace()
+
+            def execute_agent_run(
+                agent_ref: str,
+                *,
+                prompt: object,
+                request_id: str | None,
+                dependencies: dict[str, object],
+                agent_bindings: dict[str, object] | None = None,
+            ) -> Any:
+                del agent_bindings
+                assert agent_ref == "agent-from-integration"
+                assert prompt == problem_packet.brief
+                assert request_id == run_spec.run_id
+                assert dependencies["problem_packet"] is problem_packet
+                return types.SimpleNamespace(
+                    output={"text": f"{problem_packet.problem_id}:{run_spec.run_id}"},
+                    metrics={"primary_outcome": 1.0},
+                    events=[
+                        {
+                            "event_type": "assistant_output",
+                            "text": "integrated output",
+                            "actor_id": "agent",
+                        }
+                    ],
+                    trace_refs=["trace.jsonl"],
+                    metadata={"request_id": request_id or ""},
+                )
+
+            module.execute_agent_run = execute_agent_run
+            return module
         if name == "design_research_agents":
-            return types.SimpleNamespace(agent_from_module=_CallableAgent())
+            return types.SimpleNamespace()
         return importlib.import_module(name)
 
     monkeypatch.setattr(agent_adapter.importlib, "import_module", fake_import)
-    resolved = agent_adapter.resolve_agent("agent_from_module", condition=condition)
-    assert isinstance(resolved, _CallableAgent)
-
-    with pytest.raises(ValueError):
-        agent_adapter.resolve_agent("unknown-agent", condition=condition)
+    integrated_execution = agent_adapter.execute_agent(
+        agent_spec_ref="agent-from-integration",
+        run_spec=run_spec,
+        condition=condition,
+        problem_packet=problem_packet,
+    )
+    assert integrated_execution.output["text"] == "p1:run-1"
+    assert integrated_execution.metrics["primary_outcome"] == 1.0
+    assert integrated_execution.trace_refs == ["trace.jsonl"]
 
     with pytest.raises(ValueError):
         agent_adapter.execute_agent(
@@ -397,31 +429,21 @@ def test_agent_adapter_fallbacks_and_normalization(monkeypatch: pytest.MonkeyPat
     problem_packet = problem_adapter.ProblemPacket("p2", "fam", "brief text")
 
     def import_failure(name: str) -> Any:
-        """Simulate a missing upstream agent package."""
+        """Simulate an outdated sibling package missing the owner-owned seam."""
+        if name == "design_research_agents.integration":
+            raise ImportError("missing integration")
         if name == "design_research_agents":
-            raise ImportError("missing package")
+            return types.SimpleNamespace()
         return importlib.import_module(name)
 
     monkeypatch.setattr(agent_adapter.importlib, "import_module", import_failure)
-    with pytest.raises(ValueError):
-        agent_adapter.resolve_agent("missing-agent", condition=condition)
-
-    def import_constructor_fallback(name: str) -> Any:
-        """Provide an upstream constructor that cannot be zero-arg initialized."""
-        if name == "design_research_agents":
-            module = types.SimpleNamespace()
-
-            def needs_problem_context(required_context: str) -> _CallableAgent:
-                del required_context
-                return _CallableAgent()
-
-            module.needs_problem_context = needs_problem_context
-            return module
-        return importlib.import_module(name)
-
-    monkeypatch.setattr(agent_adapter.importlib, "import_module", import_constructor_fallback)
-    resolved = agent_adapter.resolve_agent("needs_problem_context", condition=condition)
-    assert callable(resolved)
+    with pytest.raises(ValueError, match="does not expose the package-owned `integration` module"):
+        agent_adapter.execute_agent(
+            agent_spec_ref="missing-agent",
+            run_spec=run_spec,
+            condition=condition,
+            problem_packet=problem_packet,
+        )
 
     def problem_and_brief_agent(*, problem: Any, brief: str) -> dict[str, Any]:
         """Use fallback keyword mapping for problem packet and brief text."""
@@ -805,8 +827,8 @@ def test_real_stack_interoperability_contracts(tmp_path: Path) -> None:
     )
 
     problem_id = "gmpb_default_dynamic_min"
-    resolved_problem = problems_module.get_problem(problem_id)
-    resolved_packet = problem_adapter.resolve_problem(resolved_problem)
+    resolved_problem = problems_module.integration.resolve_problem_binding(problem_id).problem_object
+    resolved_packet = problem_adapter.resolve_problem(problem_id)
     assert resolved_packet.problem_id == problem_id
     assert resolved_packet.family == resolved_problem.metadata.kind.value
     assert resolved_problem.metadata.title in resolved_packet.brief
@@ -909,13 +931,26 @@ def test_recipes_bundles_and_reporting(tmp_path: Path) -> None:
     brief = render_significance_brief(
         [{"test": "ttest", "outcome": "primary_outcome", "p_value": 0.04, "effect_size": 0.5}]
     )
+    object_brief = render_significance_brief(
+        types.SimpleNamespace(
+            to_significance_rows=lambda: [
+                {
+                    "test": "mannwhitney",
+                    "outcome": "secondary_outcome",
+                    "p_value": 0.03,
+                    "effect_size": 0.2,
+                }
+            ]
+        )
+    )
     empty_brief = render_significance_brief([])
 
-    report_text = "\n\n".join((summary, methods, codebook, brief, empty_brief))
+    report_text = "\n\n".join((summary, methods, codebook, brief, object_brief, empty_brief))
     report_path = write_markdown_report(study.output_dir, "summary.md", report_text)
 
     assert "# Study Summary" in summary
     assert "## Methods" in methods
     assert "## Codebook" in codebook
+    assert "mannwhitney on `secondary_outcome`" in object_brief
     assert "No analysis rows provided" in empty_brief
     assert report_path.exists()

--- a/tests/test_cli_and_examples.py
+++ b/tests/test_cli_and_examples.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import runpy
+import types
 from pathlib import Path
 
 from design_research_experiments import cli
@@ -29,11 +30,51 @@ def test_cli_roundtrip_commands(tmp_path: Path, monkeypatch: object) -> None:
     study.to_yaml(study_path)
 
     import design_research_experiments.adapters.agents as adapter_agents
+    import design_research_experiments.adapters.problems as adapter_problems
+
+    fake_problem_integration = types.SimpleNamespace(
+        resolve_problem_binding=lambda problem_id: types.SimpleNamespace(
+            problem_id=str(problem_id),
+            family="cli-family",
+            brief=f"Brief {problem_id}",
+            metadata={},
+            problem_object={"problem_id": problem_id},
+        ),
+        evaluate_problem_output=lambda _binding, _run_output: [],
+    )
+
+    def _execute_agent_run(
+        _agent_id: str,
+        *,
+        prompt: object,
+        request_id: str | None,
+        dependencies: dict[str, object],
+        agent_bindings: dict[str, object] | None = None,
+    ) -> object:
+        del prompt, agent_bindings
+        raw = _mock_agent(
+            problem_packet=dependencies["problem_packet"],
+            seed=int(dependencies["seed"]),
+        )
+        return types.SimpleNamespace(
+            output=raw["output"],
+            metrics=raw["metrics"],
+            events=raw["events"],
+            trace_refs=raw.get("trace_refs", []),
+            metadata={"request_id": request_id or ""},
+        )
+
+    fake_agent_integration = types.SimpleNamespace(execute_agent_run=_execute_agent_run)
 
     monkeypatch.setattr(
         adapter_agents,
-        "_resolve_from_design_research_agents",
-        lambda agent_id: _mock_agent if agent_id == "agent-a" else None,
+        "_load_agents_integration_module",
+        lambda: fake_agent_integration,
+    )
+    monkeypatch.setattr(
+        adapter_problems,
+        "_load_problems_integration_module",
+        lambda: fake_problem_integration,
     )
 
     assert cli.main(["validate-study", str(study_path)]) == 0
@@ -62,9 +103,26 @@ def test_cli_run_study_dry_run(tmp_path: Path, monkeypatch: object) -> None:
     study.to_json(study_path)
 
     import design_research_experiments.adapters.agents as adapter_agents
+    import design_research_experiments.adapters.problems as adapter_problems
 
     monkeypatch.setattr(
-        adapter_agents, "_resolve_from_design_research_agents", lambda _id: _mock_agent
+        adapter_agents,
+        "_load_agents_integration_module",
+        lambda: types.SimpleNamespace(execute_agent_run=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(
+        adapter_problems,
+        "_load_problems_integration_module",
+        lambda: types.SimpleNamespace(
+            resolve_problem_binding=lambda problem_id: types.SimpleNamespace(
+                problem_id=str(problem_id),
+                family="cli-family",
+                brief=f"Brief {problem_id}",
+                metadata={},
+                problem_object={"problem_id": problem_id},
+            ),
+            evaluate_problem_output=lambda _binding, _run_output: [],
+        ),
     )
 
     assert cli.main(["run-study", str(study_path), "--dry-run"]) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import importlib
 import types
 from pathlib import Path
 
 import pytest
 
 from design_research_experiments.adapters import agents as agent_adapter
+from design_research_experiments.adapters import problems as problem_adapter
 from design_research_experiments.conditions import Factor, FactorKind, Level
 from design_research_experiments.hypotheses import AnalysisPlan, Hypothesis, OutcomeSpec
 from design_research_experiments.runners import run_study
@@ -122,6 +122,9 @@ def test_run_study_executes_serial_with_callable_agent(tmp_path: Path) -> None:
     results = run_study(
         study,
         agent_bindings={"baseline": baseline_agent},
+        problem_registry={
+            "problem-1": problem_adapter.ProblemPacket("problem-1", "test-family", "brief")
+        },
         dry_run=False,
     )
 
@@ -160,14 +163,32 @@ def test_run_study_supports_public_agent_ids_without_explicit_bindings(
                 "metadata": {"request_id": request_id},
             }
 
+    def execute_agent_run(
+        agent_ref: str,
+        *,
+        prompt: object,
+        request_id: str | None,
+        dependencies: dict[str, object] | None,
+        agent_bindings: dict[str, object] | None = None,
+    ) -> object:
+        del agent_bindings
+        assert agent_ref == "SeededRandomBaselineAgent"
+        assert request_id is not None
+        assert dependencies is not None
+        agent = PublicBaselineAgent()
+        raw = agent.run(prompt, request_id=request_id, dependencies=dependencies)
+        return types.SimpleNamespace(
+            output=raw["output"],
+            metrics=raw.get("metrics", {}),
+            events=raw.get("events", []),
+            trace_refs=raw.get("trace_refs", []),
+            metadata=raw.get("metadata", {}),
+        )
+
     monkeypatch.setattr(
-        agent_adapter.importlib,
-        "import_module",
-        lambda module_name: (
-            types.SimpleNamespace(SeededRandomBaselineAgent=PublicBaselineAgent)
-            if module_name == "design_research_agents"
-            else importlib.import_module(module_name)
-        ),
+        agent_adapter,
+        "_load_agents_integration_module",
+        lambda: types.SimpleNamespace(execute_agent_run=execute_agent_run),
     )
 
     study = Study(
@@ -213,6 +234,9 @@ def test_run_study_supports_public_agent_ids_without_explicit_bindings(
 
     results = run_study(
         study,
+        problem_registry={
+            "problem-1": problem_adapter.ProblemPacket("problem-1", "test-family", "brief")
+        },
         dry_run=False,
     )
 

--- a/tests/test_io_study_schemas_and_runners.py
+++ b/tests/test_io_study_schemas_and_runners.py
@@ -133,6 +133,18 @@ def _record_progress_factory(
     return _factory
 
 
+def _standalone_problem_registry(*problem_ids: str) -> dict[str, dict[str, object]]:
+    """Build one explicit native problem registry for standalone runner tests."""
+    return {
+        problem_id: {
+            "problem_id": problem_id,
+            "family": "test_problem",
+            "brief": f"Standalone brief for {problem_id}",
+        }
+        for problem_id in problem_ids
+    }
+
+
 @dataclass(slots=True)
 class _FakeTqdmBar:
     """Minimal tqdm-compatible spy used for adapter tests."""
@@ -304,6 +316,7 @@ def test_artifact_checkpoint_bundle_and_runner_paths(tmp_path: Path) -> None:
         study,
         parallelism=2,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         checkpoint=True,
         include_sqlite=True,
     )
@@ -313,6 +326,7 @@ def test_artifact_checkpoint_bundle_and_runner_paths(tmp_path: Path) -> None:
     resumed = resume_study(
         study,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
     )
     assert len(resumed) == len(results)
 
@@ -328,6 +342,7 @@ def test_artifact_checkpoint_bundle_and_runner_paths(tmp_path: Path) -> None:
     failing_results = run_study(
         failing_study,
         agent_bindings={"agent-a": lambda _condition: _agent_failure},
+        problem_registry=_standalone_problem_registry(*failing_study.problem_ids),
         checkpoint=False,
     )
     assert len(failing_results) == 1
@@ -421,6 +436,7 @@ def test_run_study_reports_serial_progress(tmp_path: Path, monkeypatch: pytest.M
         study,
         parallelism=1,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         show_progress=True,
     )
 
@@ -458,6 +474,7 @@ def test_run_study_reports_parallel_progress(
         study,
         parallelism=2,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         show_progress=True,
     )
 
@@ -499,6 +516,7 @@ def test_resume_study_progress_tracks_completed_and_pending_runs(
         study,
         parallelism=1,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         show_progress=True,
     )
 
@@ -528,6 +546,7 @@ def test_resume_study_with_no_pending_runs_still_closes_progress(
         study,
         parallelism=1,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         checkpoint=True,
         show_progress=False,
     )
@@ -543,6 +562,7 @@ def test_resume_study_with_no_pending_runs_still_closes_progress(
         study,
         parallelism=1,
         agent_bindings={"agent-a": lambda _condition: _agent_success},
+        problem_registry=_standalone_problem_registry(*study.problem_ids),
         show_progress=True,
     )
 


### PR DESCRIPTION
## What changed
- tighten `experiments` so string problem ids delegate to `design_research_problems.integration` and string agent ids delegate to `design_research_agents.integration`
- keep explicit `ProblemPacket`, explicit registry mappings, and explicit agent bindings as the standalone/native path
- update reporting to accept analysis result objects exposing `to_significance_rows()`
- refresh tests, docs, and the real-stack example around the package-owned seam model

## Why
This repo should stay focused on orchestration and canonical artifacts rather than carrying sibling-specific normalization heuristics.

## Impact
Cross-library interoperability is now explicit and owner-owned, and `design_research_experiments` remains the orchestration surface rather than adding a symmetry-only `integration` module.

## Validation
- `PYTHONPATH=src uv run --python 3.12 --with pytest python -m pytest -q tests/test_adapters_and_reporting.py tests/test_cli_and_examples.py tests/test_core.py`
- `PYTHONPATH=src uv run --python 3.12 --with pytest python -m pytest -q tests/test_public_api.py`
