### PR TITLE
[codex] Document VS Code example path for experiments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,39 +56,19 @@ merging.
 - Keep recipe adapters thin and preserve canonical export files unless the
   release contract explicitly changes.
 
-## Release Naming
+## Release Planning
 
-- Theme: frontiers of exploration.
-- Monthly work-cycle names are shared across milestone titles, release PR
-  titles, and release branches.
-- Name the cycle for the month the work is done, not the later drop month.
-  - Milestone title / PR title: `{base name} - {Work month YYYY}`
-  - Release branch: slugified full title, for example
-    `mariner-matrix-april-2026`
-- Milestone due dates should land in the first week of the following month.
-- Milestone descriptions must use:
-  - `Work month: {Month YYYY}.`
-  - `Theme source: <url>`
-- Release PR bodies must repeat the same `Theme source:` link used on the
-  milestone and refer to the same work month named in the title.
-- Never reuse an exact base name or the same primary subject across any work
-  month or any of the four design-research module repos unless all four
-  `AGENTS.md` files are intentionally updated together.
-- Before adding a new release name, check the `Release Naming` tables in all
-  four repos to avoid repeats.
-
-| Work month | Target drop | Base name | Source subject |
-| --- | --- | --- | --- |
-| March 2026 | April 1, 2026 | Apollo Ascent | Apollo program |
-| April 2026 | May 1, 2026 | Mariner Matrix | Mariner program |
-| May 2026 | June 1, 2026 | Juno Journey | Juno spacecraft |
-| June 2026 | July 1, 2026 | Voyager Venture | Voyager program |
-| July 2026 | August 1, 2026 | Artemis Advance | Artemis program |
-| August 2026 | September 1, 2026 | Sputnik Sprint | Sputnik 1 |
-| September 2026 | October 1, 2026 | Odyssey Orbit | 2001 Mars Odyssey |
-| October 2026 | November 1, 2026 | New Horizons Nexus | New Horizons |
-| November 2026 | December 1, 2026 | Dragon Drift | Crew Dragon |
-| December 2026 | January 1, 2027 | Endeavour Expedition | Space Shuttle Endeavour |
+- Do not create monthly milestone naming tables, themed release PR names, or
+  calendar release branches as default maintenance.
+- Prefer small issue/PR-scoped planning and package version releases driven by
+  user-facing changes.
+- Use GitHub milestones only for explicit, short-lived initiatives with an
+  active owner; they are optional scheduling aids, not release gates.
+- Name release branches and release PRs for the version or concrete change set
+  they contain.
+- When publishing, update package metadata, docs, examples, and GitHub
+  Releases/PyPI notes as needed. Do not add README callouts that point to
+  monthly milestones.
 
 ## Keep This File Up To Date
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Development Setup
 
-For a step-by-step VS Code setup, including interpreter selection, optional
-`uv` usage, first checks, and troubleshooting, see
+For a step-by-step VS Code setup, including the PyPI install path, source
+checkout path, interpreter selection, first checks, and troubleshooting, see
 [VS Code Start](docs/vscode_start.rst).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ intentionally no separate `design_research_experiments.integration` module.
 
 Requires Python 3.12+.
 Maintainer workflows target Python `3.12` (`.python-version`).
-For a VS Code-oriented contributor setup, see
+For a VS Code path that starts from PyPI and then shows the repository example
+workflow, see
 [VS Code Start](docs/vscode_start.rst).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-experiments.svg)](https://pypi.org/project/design-research-experiments/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-experiments.svg)](https://pypi.org/project/design-research-experiments/)
 
-<!-- release-callout:start -->
-> [!IMPORTANT]
-> Current monthly release: [Juno Journey - May 2026](https://github.com/cmudrc/design-research-experiments/milestone/3)  
-> Due: June 1, 2026  
-> Tracks: May 2026 work
-<!-- release-callout:end -->
-
 `design-research-experiments` is the hypothesis-first study-definition and
 experiment-orchestration layer in the cmudrc design research ecosystem.
 

--- a/docs/automation_baseline.rst
+++ b/docs/automation_baseline.rst
@@ -6,8 +6,9 @@ This page documents the shared docs and CI baseline for
 
 The experiments repo follows the common module pattern used across the family:
 docs surfaces are checked for consistency and example health is reported
-explicitly. Release state is tracked in GitHub milestones and release branches
-instead of generated README callouts.
+explicitly. Release state is tracked through package versions, GitHub Releases,
+and focused PRs instead of generated README callouts or default monthly
+milestones.
 
 Shared Module Baseline
 ----------------------

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -1,8 +1,13 @@
-VS Code Start
-=============
+Run An Example In VS Code
+=========================
 
-Use this path when opening ``design-research-experiments`` in VS Code for the
-first time. The commands are repo-local and assume Python 3.12 or newer.
+Use this page when you want to try ``design-research-experiments`` in VS Code.
+Choose the installed-package path for a first user workflow, or the source
+checkout path when you want to run the repository's checked-in examples and
+development checks.
+
+The checked-in ``examples/`` directory lives in the repository source. Do not
+assume those files are present inside the PyPI wheel.
 
 Requirements
 ------------
@@ -10,64 +15,31 @@ Requirements
 - Python 3.12 or newer. Maintainer workflows target the version in
   ``.python-version``.
 - VS Code with the Python extension.
-- ``make`` available in the integrated terminal.
-- Optional: ``uv`` for faster virtual environment and package installs.
+- A VS Code integrated terminal.
 
-Open the Repository
--------------------
+Installed Package From PyPI
+---------------------------
 
-Open the repository root folder in VS Code, not the parent ecosystem folder. The
-root should contain ``pyproject.toml``, ``Makefile``, ``src/``, ``tests/``, and
-``examples/``.
+Open an empty folder in VS Code, then create and activate a virtual
+environment from ``Terminal > New Terminal``.
 
-Create an Environment
----------------------
-
-Standard library setup:
+On macOS or Linux:
 
 .. code-block:: bash
 
    python -m venv .venv
    source .venv/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install design-research-experiments
 
-On Windows PowerShell, use:
+On Windows PowerShell:
 
 .. code-block:: powershell
 
    py -3.12 -m venv .venv
-   .venv\Scripts\Activate.ps1
-
-With ``uv``:
-
-.. code-block:: bash
-
-   uv venv --python 3.12
-   source .venv/bin/activate
-
-Install Development Dependencies
---------------------------------
-
-Use the maintainer shortcut:
-
-.. code-block:: bash
-
-   make dev
-
-Equivalent ``pip`` command:
-
-.. code-block:: bash
-
-   python -m pip install --upgrade pip setuptools wheel
-   python -m pip install -e ".[dev]"
-
-Equivalent ``uv`` command:
-
-.. code-block:: bash
-
-   uv pip install -e ".[dev]"
-
-Select the VS Code Interpreter
-------------------------------
+   .\.venv\Scripts\Activate.ps1
+   python -m pip install --upgrade pip
+   python -m pip install design-research-experiments
 
 Run ``Python: Select Interpreter`` from the command palette and choose the
 interpreter inside ``.venv``. If VS Code does not list it, enter the interpreter
@@ -76,8 +48,62 @@ path manually:
 - macOS/Linux: ``.venv/bin/python``
 - Windows: ``.venv\Scripts\python.exe``
 
-First Checks
-------------
+Create ``experiments_example.py`` in the workspace folder:
+
+.. code-block:: python
+
+   from design_research_experiments import (
+       build_design,
+       build_prompt_framing_study,
+       validate_study,
+   )
+
+   study = build_prompt_framing_study()
+   errors = validate_study(study)
+   if errors:
+       raise RuntimeError("\n".join(errors))
+
+   conditions = build_design(study)
+   print(study.study_id)
+   print(f"conditions: {len(conditions)}")
+
+Run the file with VS Code's ``Run Python File`` action, or run:
+
+.. code-block:: bash
+
+   python experiments_example.py
+
+Source Checkout For Repository Examples
+---------------------------------------
+
+Use this path when you want the checked-in examples, docs, tests, and optional
+development tooling.
+
+.. code-block:: bash
+
+   git clone https://github.com/cmudrc/design-research-experiments.git
+   cd design-research-experiments
+   python -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip setuptools wheel
+   python -m pip install -e ".[dev]"
+
+Equivalent maintainer shortcut:
+
+.. code-block:: bash
+
+   make dev
+
+Run the deterministic example path from the integrated terminal:
+
+.. code-block:: bash
+
+   make run-example
+   make examples-test
+   python examples/basic_usage.py
+
+First Development Checks
+------------------------
 
 Run the checks from VS Code's integrated terminal:
 
@@ -90,21 +116,15 @@ Run the checks from VS Code's integrated terminal:
 ``make qa`` runs linting, formatting checks, type checks, and tests. Run
 ``make coverage`` before merge when changing tested behavior.
 
-Deterministic Examples
-----------------------
+Optional Backends
+-----------------
 
-Run the deterministic example path from the integrated terminal:
-
-.. code-block:: bash
-
-   make run-example
-   make examples-test
-
-To run the primary script directly:
+Install optional design-of-experiments backends only when a workflow needs
+them:
 
 .. code-block:: bash
 
-   PYTHONPATH=src python examples/basic_usage.py
+   python -m pip install -e ".[doe]"
 
 Troubleshooting
 ---------------
@@ -113,8 +133,8 @@ Troubleshooting
   interpreter and reload the window.
 - If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
   ``PYTHON=.venv/bin/python make test``.
-- If Windows activation is blocked, enable script execution for the current
-  user or use the VS Code Python extension's environment activation.
+- If Windows activation is blocked, switch the terminal profile to Command
+  Prompt and run ``.\.venv\Scripts\activate.bat``.
 - If optional design-of-experiments backends are needed, install
   ``pip install -e ".[doe]"`` inside the active environment.
 - Avoid committing generated runtime output under ``artifacts/``,

--- a/src/design_research_experiments/adapters/agents.py
+++ b/src/design_research_experiments/adapters/agents.py
@@ -81,7 +81,7 @@ def execute_agent(
         if owner_integration is None:
             raise ValidationError(
                 "String agent references now require `design_research_agents.integration`. "
-                "Install the coordinated monthly release or use an explicit binding/object."
+                "Install a compatible package release or use an explicit binding/object."
             )
         return _execute_via_owner_integration(
             owner_integration=owner_integration,
@@ -145,7 +145,7 @@ def _load_agents_integration_module() -> Any | None:
             return None
         raise ValidationError(
             "design-research-agents is installed but does not expose the package-owned "
-            "`integration` module. Upgrade to the coordinated monthly release."
+            "`integration` module. Upgrade to a compatible package release."
         ) from exc
 
 

--- a/src/design_research_experiments/adapters/problems.py
+++ b/src/design_research_experiments/adapters/problems.py
@@ -43,7 +43,7 @@ def resolve_problem(
         if owner_integration is None:
             raise ValidationError(
                 "String problem references now require `design_research_problems.integration`. "
-                "Install the coordinated monthly release or pass an explicit `ProblemPacket` "
+                "Install a compatible package release or pass an explicit `ProblemPacket` "
                 "through `problem_registry`."
             )
         binding = owner_integration.resolve_problem_binding(problem_spec_ref)
@@ -171,7 +171,7 @@ def _load_problems_integration_module() -> Any | None:
             return None
         raise ValidationError(
             "design-research-problems is installed but does not expose the package-owned "
-            "`integration` module. Upgrade to the coordinated monthly release."
+            "`integration` module. Upgrade to a compatible package release."
         ) from exc
 
 
@@ -198,7 +198,7 @@ def _evaluate_owner_problem(
     if not callable(evaluate):
         raise ValidationError(
             "design-research-problems is installed but does not expose "
-            "`evaluate_problem_output(...)`. Upgrade to the coordinated monthly release."
+            "`evaluate_problem_output(...)`. Upgrade to a compatible package release."
         )
 
     rows = evaluate(binding, run_output)


### PR DESCRIPTION
## Summary
- make the VS Code guide start with a PyPI install path and pasteable public-API example
- keep a separate source checkout path for repository examples, dev dependencies, checks, and optional backends
- update README and CONTRIBUTING links so the PyPI/source split is visible from the first-run path
- remove the README monthly release callout and AGENTS monthly release naming table
- reword automation docs and compatibility messages away from coordinated monthly releases toward compatible package releases
- keep future release planning issue/PR-scoped, with GitHub milestones treated as optional short-lived aids rather than release gates

Refs cmudrc/design-research#22

## Verification
- PyPI smoke-tested the documented starter snippets in a clean virtualenv
- `make docs-check`
- `make docs-build`
- `make test`