### PR TITLE
[codex] Prepare design-research-experiments 0.2.1

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="116"
-    height="20" role="img" aria-label="Test Coverage: 92%">
+    height="20" role="img" aria-label="Test Coverage: 95%">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -18,7 +18,7 @@
   font-size="11">
     <text x="44.0" y="15" fill="#010101" fill-opacity=".3">Test Coverage</text>
     <text x="44.0" y="14">Test Coverage</text>
-    <text x="102.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-    <text x="102.0" y="14">92%</text>
+    <text x="102.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
+    <text x="102.0" y="14">95%</text>
   </g>
 </svg>

--- a/.github/badges/examples-api-coverage.svg
+++ b/.github/badges/examples-api-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="170"
-    height="20" role="img" aria-label="Example API Coverage: 53/54">
+<svg xmlns="http://www.w3.org/2000/svg" width="140"
+    height="20" role="img" aria-label="API in Examples: 55/55">
   <linearGradient id="g" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -7,18 +7,18 @@
     <stop offset="1" stop-opacity=".5"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="170" height="20" rx="3" fill="#fff"/>
+    <rect width="140" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#r)">
-    <rect width="130" height="20" fill="#555"/>
-    <rect x="130" width="40" height="20" fill="#4c1"/>
-    <rect width="170" height="20" fill="url(#g)"/>
+    <rect width="100" height="20" fill="#555"/>
+    <rect x="100" width="40" height="20" fill="#4c1"/>
+    <rect width="140" height="20" fill="url(#g)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
   font-size="11">
-    <text x="65.0" y="15" fill="#010101" fill-opacity=".3">Example API Coverage</text>
-    <text x="65.0" y="14">Example API Coverage</text>
-    <text x="150.0" y="15" fill="#010101" fill-opacity=".3">53/54</text>
-    <text x="150.0" y="14">53/54</text>
+    <text x="50.0" y="15" fill="#010101" fill-opacity=".3">API in Examples</text>
+    <text x="50.0" y="14">API in Examples</text>
+    <text x="120.0" y="15" fill="#010101" fill-opacity=".3">55/55</text>
+    <text x="120.0" y="14">55/55</text>
   </g>
 </svg>

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,78 +1,113 @@
-# GitHub Actions workflow to publish `design-research-experiments` to PyPI.
-#
-# Goals:
-# - Build sdist + wheel deterministically on a clean runner.
-# - Validate artifacts (metadata + README rendering hints) before upload.
-# - Publish via **trusted publishing** (OIDC), avoiding long-lived PyPI tokens.
-# - Allow both automatic publishes (GitHub Releases) and manual runs (workflow_dispatch).
-#
-# Assumptions:
-# - You have configured PyPI trusted publishing for this repo + the `pypi` environment.
-# - The `pypi` environment can optionally enforce approvals / protection rules.
-
 name: Publish
 
-# Triggers:
-# - On GitHub Release publish events (recommended: release-driven versioning).
-# - Manual trigger for re-runs / hotfixes (useful if PyPI upload failed transiently).
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the validated artifacts to PyPI
+        required: true
+        default: false
+        type: boolean
 
-# Default permissions are read-only; we elevate only what we need inside the job.
 permissions:
   contents: read
 
-jobs:
-  publish:
-    name: Build and publish distribution
+concurrency:
+  group: publish-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
-    # Use GitHub-hosted Ubuntu runner for a clean, reproducible build environment.
+jobs:
+  build:
+    name: Build and validate distributions
     runs-on: ubuntu-latest
 
-    # Attach this job to the `pypi` environment so you can:
-    # - require approvals
-    # - restrict who can deploy
-    # - view a friendly link to the deployed package
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Verify publishing tag matches package version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PUBLISH: ${{ inputs.publish }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          package_name = "design-research-experiments"
+          project = tomllib.loads(
+              pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
+          )["project"]
+          expected_tag = f"v{project['version']}"
+          event_name = os.environ["EVENT_NAME"]
+          manual_publish = os.environ.get("MANUAL_PUBLISH", "").lower() == "true"
+
+          if event_name == "release":
+              actual_tag = os.environ["RELEASE_TAG"]
+          elif manual_publish:
+              if os.environ["REF_TYPE"] != "tag":
+                  raise SystemExit(
+                      "Manual publishing must be dispatched from the release tag, "
+                      f"not {os.environ['REF_TYPE']} {os.environ['REF_NAME']!r}."
+                  )
+              actual_tag = os.environ["REF_NAME"]
+          else:
+              actual_tag = None
+
+          if actual_tag is not None and actual_tag != expected_tag:
+              raise SystemExit(
+                  f"Tag {actual_tag!r} does not match package version {expected_tag!r}."
+              )
+
+          mode = "publish" if actual_tag is not None else "build-only"
+          print(f"Preparing {package_name} {project['version']} ({mode}).")
+          PY
+
+      - name: Install release tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build and validate distribution artifacts
+        run: make release-check
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish distributions to PyPI
+    needs: build
+    if: github.event_name == 'release' || inputs.publish == true
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/design-research-experiments
-
-    # Job-scoped permissions:
-    # - contents: read is enough to check out the repo.
-    # - id-token: write is REQUIRED for OIDC trusted publishing (no password/token).
     permissions:
       contents: read
       id-token: write
 
     steps:
-      # Fetch the repository contents for building.
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Install a pinned Python runtime for consistent builds.
-      # `cache: pip` speeds up repeated runs by caching downloaded wheels.
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.12"
-          cache: pip
+          name: python-package-distributions
+          path: dist
 
-      # Build source and wheel distributions, then sanity-check them.
-      #
-      # - build: produces dist/*.tar.gz (sdist) and dist/*.whl (wheel)
-      # - twine check: validates metadata and long_description rendering markers
-      #   (catches common README/metadata packaging issues early).
-      - name: Build distribution artifacts
-        run: |
-          python -m pip install --upgrade pip build twine
-          python -m build
-          python -m twine check dist/*
-
-      # Publish to PyPI using OIDC (trusted publishing).
-      #
-      # This action exchanges the GitHub OIDC token for a short-lived PyPI token
-      # behind the scenes. No secrets required in the repo.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .nox/
-.coverage
-.coverage.*
+.coverage*
 .cache
 nosetests.xml
 coverage.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ merging.
 ## Behavioral Guardrails
 
 - Keep tests deterministic and offline by default.
-- Maintain the hard 90% total line-coverage floor enforced in CI via
+- Maintain the hard 95% total line-coverage floor enforced in CI via
   `make coverage`; this repo-specific baseline tracks
   [cmudrc/design-research#4](https://github.com/cmudrc/design-research/issues/4).
 - Update tests, docs, and examples alongside behavior changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,11 @@ make docs-check
 make docs
 ```
 
-This repo maintains a hard 90% total line-coverage floor in CI. Run
-`make coverage` before merge when touching tested behavior. This repo-level
-baseline tracks the family-wide policy in
-[cmudrc/design-research#4](https://github.com/cmudrc/design-research/issues/4).
+## Quality Gates
+
+- `make coverage` enforces at least 95% total line coverage for the default deterministic suite.
+- `make examples-test` executes the checked-in runnable examples.
+- `make examples-coverage` requires every curated top-level `__all__` export to appear in at least one runnable example.
 
 Optional but useful:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,17 @@ make dev
 
 The preferred maintainer interpreter is set in `.python-version` (`3.12`).
 
-Before cutting a release, run:
+## Release Publishing
 
-```bash
-make release-check
-```
+Before cutting a release, run `make release-check`. The GitHub `Publish`
+workflow builds and validates distributions before any upload:
+
+- Publishing a GitHub Release tagged `v{package-version}` publishes to PyPI.
+- A manual workflow run is build-only by default.
+- A recovery publish requires selecting the release tag and explicitly setting
+  `publish=true`; publishing from a branch is rejected.
+- Every publishing path rejects a tag that differs from the version in
+  `pyproject.toml`.
 
 ## Local Quality Checks
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MYPY ?= $(PYTHON) -m mypy
 SPHINX ?= $(PYTHON) -m sphinx
 BUILD ?= $(PYTHON) -m build
 TWINE ?= $(PYTHON) -m twine
-COVERAGE_MIN ?= 90
+COVERAGE_MIN ?= 95
 
 .PHONY: help check-python dev install-dev \
 	lint fmt fmt-check type test qa coverage docstrings-check \
@@ -19,11 +19,11 @@ help:
 	@echo "  dev              Install the project in editable mode with dev dependencies."
 	@echo "  test             Run the pytest suite."
 	@echo "  qa               Run lint, fmt-check, type, and test."
-	@echo "  coverage         Enforce the 90% total coverage floor and emit coverage artifacts."
+	@echo "  coverage         Enforce the 95% total line-coverage floor and emit artifacts."
 	@echo "  run-example      Execute the bundled example script."
 	@echo "  run-examples     Execute all bundled example scripts."
 	@echo "  examples-test    Execute all bundled example scripts."
-	@echo "  examples-coverage Check public API coverage across examples."
+	@echo "  examples-coverage Require every public API export to appear in an example."
 	@echo "  examples-metrics Generate example and public-API badge artifacts."
 	@echo "  docs             Build the HTML docs."
 	@echo "  ci               Run the main local CI checks."
@@ -74,8 +74,8 @@ examples-test: check-python
 
 run-examples: examples-test
 
-examples-coverage: check-python
-	$(PYTHON) scripts/check_example_api_coverage.py --minimum 90
+examples-coverage: check-python examples-metrics
+	$(PYTHON) scripts/check_example_api_coverage.py --minimum 100
 
 examples-metrics: check-python examples-test
 	$(PYTHON) scripts/generate_examples_metrics.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CI](https://github.com/cmudrc/design-research-experiments/actions/workflows/ci.yml/badge.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/ci.yml)
 [![Coverage](https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/coverage.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/ci.yml)
 [![Examples Passing](https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-passing.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/examples.yml)
-[![Public API In Examples](https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-api-coverage.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/examples.yml)
+[![API in Examples](https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-api-coverage.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/examples.yml)
 [![Docs](https://github.com/cmudrc/design-research-experiments/actions/workflows/docs-pages.yml/badge.svg)](https://github.com/cmudrc/design-research-experiments/actions/workflows/docs-pages.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/design-research-experiments.svg)](https://pypi.org/project/design-research-experiments/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/design-research-experiments.svg)](https://pypi.org/project/design-research-experiments/)
@@ -15,6 +15,14 @@ It composes sibling libraries rather than reimplementing them:
 - `design-research-agents` for executable agent behavior, workflows, and traces
 - `design-research-problems` for problem catalogs, registries, and evaluators
 - `design-research-analysis` for downstream unified-table analysis and reporting
+
+## Quality Signals
+
+- **Coverage** reports total line coverage for the default deterministic test suite; CI requires at least 95%.
+- **Examples Passing** reports checked-in example scripts that execute successfully in the examples workflow.
+- **API in Examples** reports curated top-level `__all__` exports referenced by runnable examples. `N/N` means every supported top-level export appears in at least one example, and CI requires 100%.
+
+Run `make coverage`, `make examples-test`, and `make examples-coverage` to reproduce these checks locally.
 
 ## Overview
 
@@ -56,7 +64,7 @@ Run a basic example:
 make run-example
 ```
 
-This repo maintains a hard 90% total line-coverage floor in CI via
+This repo maintains a hard 95% total line-coverage floor in CI via
 `make coverage`. The repo-specific rule tracks the family-wide coverage policy
 in [cmudrc/design-research#4](https://github.com/cmudrc/design-research/issues/4).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ made.
           <img alt="Examples Passing" src="https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-passing.svg">
         </a>
         <a class="drc-badge-link" href="https://github.com/cmudrc/design-research-experiments/actions/workflows/examples.yml">
-          <img alt="Public API In Examples" src="https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-api-coverage.svg">
+          <img alt="API in Examples" src="https://raw.githubusercontent.com/cmudrc/design-research-experiments/HEAD/.github/badges/examples-api-coverage.svg">
         </a>
         <a class="drc-badge-link" href="https://github.com/cmudrc/design-research-experiments/actions/workflows/docs-pages.yml">
           <img alt="Docs" src="https://github.com/cmudrc/design-research-experiments/actions/workflows/docs-pages.yml/badge.svg">
@@ -43,6 +43,20 @@ made.
           <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/design-research-experiments.svg">
         </a>
       </div>
+
+Quality Signals
+---------------
+
+- ``Coverage`` reports total line coverage for the default deterministic test
+  suite; CI requires at least 95%.
+- ``Examples Passing`` reports checked-in example scripts that execute
+  successfully in the examples workflow.
+- ``API in Examples`` reports curated top-level ``__all__`` exports referenced
+  by runnable examples. ``N/N`` means every supported top-level export appears
+  in at least one example, and CI requires 100%.
+
+Run ``make coverage``, ``make examples-test``, and ``make examples-coverage``
+to reproduce these checks locally.
 
 Highlights
 ----------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -28,9 +28,3 @@ Primary modules and responsibilities:
 - ``design_research_experiments.adapters``: thin orchestration glue that delegates
   sibling-package interoperability to owner-owned ``integration`` modules.
 - ``design_research_experiments.io``: YAML/JSON/CSV/SQLite persistence helpers.
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ../artifact_contract

--- a/examples/public_api_walkthrough.py
+++ b/examples/public_api_walkthrough.py
@@ -66,8 +66,17 @@ def build_demo_study(output_dir: Path) -> drex.Study:
 
 def main() -> None:
     """Validate and materialize the demo study."""
+    print(f"design-research-experiments {drex.__version__}")
     output_dir = Path("artifacts") / "demo-study"
     study = build_demo_study(output_dir)
+    packet = drex.resolve_problem(
+        {
+            "problem_id": "problem-1",
+            "family": "walkthrough",
+            "brief": "A locally defined problem packet for the walkthrough.",
+        }
+    )
+    print(f"Resolved problem packet: {packet.problem_id}")
 
     errors = drex.validate_study(study)
     if errors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "design-research-experiments"
-version = "0.2.0"
+version = "0.2.1"
 description = "Study-definition and orchestration layer for the cmudrc design research ecosystem"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/check_example_api_coverage.py
+++ b/scripts/check_example_api_coverage.py
@@ -70,7 +70,7 @@ def _usage_from_notebook(path: Path, exports: set[str]) -> set[str]:
 def main() -> int:
     """Compute example API-usage coverage and enforce a threshold."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--minimum", type=float, default=90.0)
+    parser.add_argument("--minimum", type=float, default=100.0)
     args = parser.parse_args()
 
     exports = _extract_exports(PUBLIC_API_INIT)
@@ -92,7 +92,7 @@ def main() -> int:
     coverage_percent = (len(covered) / len(exports)) * 100.0 if exports else 100.0
     missing = sorted(export_set - covered)
 
-    print(f"Example API coverage: {coverage_percent:.1f}% ({len(covered)}/{len(exports)})")
+    print(f"API in examples: {coverage_percent:.1f}% ({len(covered)}/{len(exports)})")
     if missing:
         print("Missing exports in examples:")
         for symbol in missing:
@@ -102,7 +102,7 @@ def main() -> int:
         print(f"Coverage threshold failed: {coverage_percent:.1f}% < {args.minimum:.1f}%")
         return 1
 
-    print("Example API coverage threshold passed.")
+    print("API-in-examples threshold passed.")
     return 0
 
 

--- a/scripts/generate_examples_badges.py
+++ b/scripts/generate_examples_badges.py
@@ -125,7 +125,7 @@ def main() -> None:
     )
     API_BADGE.write_text(
         _render_badge(
-            "Example API Coverage",
+            "API in Examples",
             f"{covered_exports}/{total_exports}",
             _pick_color(api_coverage_percent),
         ),

--- a/scripts/generate_examples_metrics.py
+++ b/scripts/generate_examples_metrics.py
@@ -36,7 +36,7 @@ def _extract_exports(path: Path) -> tuple[str, ...]:
         path: Package ``__init__.py`` path.
 
     Returns:
-        Tuple of exported symbol names excluding ``__version__``.
+        Tuple of exported symbol names.
 
     Raises:
         ValueError: If the module does not define a static ``__all__`` list or tuple.
@@ -52,11 +52,7 @@ def _extract_exports(path: Path) -> tuple[str, ...]:
 
         exports: list[str] = []
         for element in node.value.elts:
-            if (
-                isinstance(element, ast.Constant)
-                and isinstance(element.value, str)
-                and element.value != "__version__"
-            ):
+            if isinstance(element, ast.Constant) and isinstance(element.value, str):
                 exports.append(element.value)
         return tuple(exports)
 

--- a/src/design_research_experiments/__init__.py
+++ b/src/design_research_experiments/__init__.py
@@ -1,5 +1,7 @@
 """Public API exports for design-research-experiments."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .adapters.analysis import export_analysis_tables
 from .adapters.problems import ProblemPacket, resolve_problem
 from .bundles import (
@@ -45,6 +47,11 @@ from .runners import agent_result, resume_study, run_study
 from .schemas import RunBudget, SeedPolicy
 from .study import Block, RunResult, RunSpec, Study, validate_study
 
+try:
+    __version__ = version("design-research-experiments")
+except PackageNotFoundError:
+    __version__ = "0+unknown"
+
 __all__ = [
     "AgentArchitectureComparisonConfig",
     "AnalysisPlan",
@@ -73,6 +80,7 @@ __all__ = [
     "StrategyComparisonConfig",
     "Study",
     "UnivariateComparisonConfig",
+    "__version__",
     "agent_result",
     "build_agent_architecture_comparison_study",
     "build_bivariate_comparison_study",

--- a/src/design_research_experiments/adapters/analysis.py
+++ b/src/design_research_experiments/adapters/analysis.py
@@ -48,10 +48,13 @@ def export_analysis_tables(
 
 
 def _run_optional_analysis_validation(events_csv_path: Path) -> None:
-    """Optionally run validation hooks from design-research-analysis when available."""
+    """Run validation hooks from design-research-analysis when requested."""
     module = _load_analysis_validation_module()
     if module is None:
-        return
+        raise ValidationError(
+            "`validate_with_analysis_package=True` requires design-research-analysis. "
+            "Install it with `pip install design-research-analysis`."
+        )
 
     validator = getattr(module, "validate_experiment_events", None)
     if not callable(validator):

--- a/tests/test_adapters_and_reporting.py
+++ b/tests/test_adapters_and_reporting.py
@@ -809,6 +809,92 @@ def test_analysis_adapter_raises_when_validation_report_fails(
         )
 
 
+def test_analysis_adapter_optional_validation_absent_package_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Optional analysis validation should skip cleanly when the sibling package is absent."""
+    study = make_study(tmp_path=tmp_path, study_id="analysis-absent")
+    conditions = build_design(study)
+
+    def fake_import(name: str) -> Any:
+        if name.startswith("design_research_analysis"):
+            raise ImportError("missing optional analysis package", name="design_research_analysis")
+        return importlib.import_module(name)
+
+    monkeypatch.setattr(analysis_adapter.importlib, "import_module", fake_import)
+
+    paths = analysis_adapter.export_analysis_tables(
+        study,
+        conditions=conditions,
+        run_results=[],
+        output_dir=tmp_path / "analysis-absent-out",
+        validate_with_analysis_package=True,
+    )
+
+    assert paths["events.csv"].exists()
+
+
+def test_analysis_adapter_rejects_outdated_installed_analysis_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An installed analysis package without the artifact API should fail loudly."""
+    study = make_study(tmp_path=tmp_path, study_id="analysis-outdated")
+    conditions = build_design(study)
+
+    def fake_import(name: str) -> Any:
+        if name == "design_research_analysis":
+            return types.SimpleNamespace()
+        if name == "design_research_analysis.integration":
+            raise ImportError(
+                "integration module missing",
+                name="design_research_analysis.integration",
+            )
+        return importlib.import_module(name)
+
+    monkeypatch.setattr(analysis_adapter.importlib, "import_module", fake_import)
+
+    with pytest.raises(ValueError, match="artifact-first validation API"):
+        analysis_adapter.export_analysis_tables(
+            study,
+            conditions=conditions,
+            run_results=[],
+            output_dir=tmp_path / "analysis-outdated-out",
+            validate_with_analysis_package=True,
+        )
+
+
+def test_analysis_adapter_rejects_module_without_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded validation module must expose a callable validator."""
+    monkeypatch.setattr(
+        analysis_adapter,
+        "_load_analysis_validation_module",
+        lambda: types.SimpleNamespace(validate_experiment_events="not-callable"),
+    )
+
+    with pytest.raises(ValueError, match="does not expose"):
+        analysis_adapter._run_optional_analysis_validation(Path("events.csv"))
+
+
+def test_analysis_adapter_uses_generic_message_for_non_sequence_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validation reports with non-sequence errors should keep the fallback message."""
+
+    def validate_experiment_events(_path: Path) -> Any:
+        return types.SimpleNamespace(is_valid=False, errors=object())
+
+    monkeypatch.setattr(
+        analysis_adapter,
+        "_load_analysis_validation_module",
+        lambda: types.SimpleNamespace(validate_experiment_events=validate_experiment_events),
+    )
+
+    with pytest.raises(ValueError, match="Unified table validation failed"):
+        analysis_adapter._run_optional_analysis_validation(Path("events.csv"))
+
+
 def test_real_stack_interoperability_contracts(tmp_path: Path) -> None:
     """When sibling repos are available, the real stack should compose end to end."""
     problems_module = _import_sibling_module(

--- a/tests/test_adapters_and_reporting.py
+++ b/tests/test_adapters_and_reporting.py
@@ -42,7 +42,12 @@ from design_research_experiments.reporting import (
     render_significance_brief,
     write_markdown_report,
 )
-from design_research_experiments.schemas import Observation, ObservationLevel, RunStatus
+from design_research_experiments.schemas import (
+    Observation,
+    ObservationLevel,
+    RunStatus,
+    ValidationError,
+)
 from design_research_experiments.study import RunBudget, RunResult, RunSpec, Study, validate_study
 
 from .helpers import make_study
@@ -809,10 +814,10 @@ def test_analysis_adapter_raises_when_validation_report_fails(
         )
 
 
-def test_analysis_adapter_optional_validation_absent_package_is_noop(
+def test_analysis_adapter_requires_analysis_package_for_requested_validation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Optional analysis validation should skip cleanly when the sibling package is absent."""
+    """Requested analysis validation should fail clearly when its dependency is absent."""
     study = make_study(tmp_path=tmp_path, study_id="analysis-absent")
     conditions = build_design(study)
 
@@ -823,15 +828,14 @@ def test_analysis_adapter_optional_validation_absent_package_is_noop(
 
     monkeypatch.setattr(analysis_adapter.importlib, "import_module", fake_import)
 
-    paths = analysis_adapter.export_analysis_tables(
-        study,
-        conditions=conditions,
-        run_results=[],
-        output_dir=tmp_path / "analysis-absent-out",
-        validate_with_analysis_package=True,
-    )
-
-    assert paths["events.csv"].exists()
+    with pytest.raises(ValidationError, match="pip install design-research-analysis"):
+        analysis_adapter.export_analysis_tables(
+            study,
+            conditions=conditions,
+            run_results=[],
+            output_dir=tmp_path / "analysis-absent-out",
+            validate_with_analysis_package=True,
+        )
 
 
 def test_analysis_adapter_rejects_outdated_installed_analysis_package(

--- a/tests/test_adapters_and_reporting.py
+++ b/tests/test_adapters_and_reporting.py
@@ -210,13 +210,35 @@ def test_problem_adapter_resolution_and_sampling(monkeypatch: pytest.MonkeyPatch
         }
     )
     assert packet.problem_id == "p-map"
+    assert problem_adapter.resolve_problem(packet) is packet
     assert problem_adapter.evaluate_problem(packet, {"text": "x"})[0]["metric_name"] == "score"
+    empty_result_packet = problem_adapter.ProblemPacket(
+        "p-empty",
+        "mapped",
+        "empty result",
+        evaluator=lambda _output: None,
+    )
+    assert problem_adapter.evaluate_problem(empty_result_packet, {}) == []
 
     registry_packet = problem_adapter.ProblemPacket("p-reg", "reg", "brief")
     resolved_registry = problem_adapter.resolve_problem(
         "p-reg", registry={"p-reg": registry_packet}
     )
     assert resolved_registry is registry_packet
+    assert problem_adapter.sample_problem_packets([packet, registry_packet]) == [
+        packet,
+        registry_packet,
+    ]
+    assert (
+        len(
+            problem_adapter.sample_problem_packets(
+                [packet, registry_packet],
+                sample_size=1,
+                seed=2,
+            )
+        )
+        == 1
+    )
 
     calls: list[str] = []
 
@@ -324,6 +346,22 @@ def test_problem_adapter_raises_clear_error_for_outdated_problem_package(
 
     with pytest.raises(ValueError, match="does not expose the package-owned `integration` module"):
         problem_adapter.resolve_problem("outdated-problem")
+
+
+def test_problem_adapter_rejects_missing_owner_package_and_invalid_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable owner packages and invalid registries should fail clearly."""
+
+    def missing_import(_name: str) -> Any:
+        raise ImportError("package unavailable")
+
+    monkeypatch.setattr(problem_adapter.importlib, "import_module", missing_import)
+
+    with pytest.raises(ValueError, match="String problem references now require"):
+        problem_adapter.resolve_problem("missing-problem")
+    with pytest.raises(ValueError, match="Problem registries now require"):
+        problem_adapter.resolve_problem("invalid", registry={"invalid": object()})
 
 
 def test_agent_adapter_execution_paths(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -208,3 +208,45 @@ def test_validate_canonical_artifacts_fails_loudly_on_contract_drift(tmp_path: P
 
     with pytest.raises(ValueError, match=r"events\.csv is missing required columns"):
         validate_canonical_artifacts(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("drift", "expected_message"),
+    [
+        ("missing-file", r"Missing canonical artifacts: evaluations\.csv"),
+        ("missing-key", r"manifest\.json is missing required keys: generated_at"),
+        ("schema-version", r"manifest\.json schema_version 'invalid' does not match"),
+        ("study-id", r"study\.yaml and manifest\.json disagree on study_id"),
+    ],
+)
+def test_validate_canonical_artifacts_reports_structural_drift(
+    tmp_path: Path,
+    drift: str,
+    expected_message: str,
+) -> None:
+    """Every structural contract failure should identify the offending artifact."""
+    output_dir = tmp_path / drift
+    study = build_strategy_comparison_study()
+    study.output_dir = output_dir
+    export_canonical_artifacts(
+        study=study,
+        conditions=build_design(study),
+        run_results=[],
+        output_dir=output_dir,
+    )
+
+    manifest_path = output_dir / "manifest.json"
+    if drift == "missing-file":
+        (output_dir / "evaluations.csv").unlink()
+    else:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if drift == "missing-key":
+            manifest.pop("generated_at")
+        elif drift == "schema-version":
+            manifest["schema_version"] = "invalid"
+        else:
+            manifest["study_id"] = "different-study"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected_message):
+        validate_canonical_artifacts(output_dir)

--- a/tests/test_conditions_and_designs_extended.py
+++ b/tests/test_conditions_and_designs_extended.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from design_research_experiments import designs as designs_module
 from design_research_experiments.conditions import (
     Constraint,
     ConstraintSeverity,
@@ -80,6 +81,12 @@ def test_condition_expression_engine_and_validation(tmp_path: Path) -> None:
 
     with pytest.raises(ValidationError):
         DesignSpec(replicates=0)
+
+    with pytest.raises(ValidationError):
+        DesignSpec(n_samples=0)
+
+    with pytest.raises(ValidationError):
+        DesignSpec(center_points=-1)
 
     with pytest.raises(ValidationError):
         Block(name="", levels=("x",))
@@ -342,11 +349,58 @@ def test_design_helper_functions_cover_error_and_summary_paths(tmp_path: Path) -
     with pytest.raises(ValidationError, match="Latin-hypercube factor definitions"):
         generate_doe(kind="lhs", factors={"x": ["low", "high"]}, n_samples=2)
 
+    label_only = generate_doe(kind="full", factors={"variant": ["a", "b"]}, randomize=False)
+    assert label_only["summary"]["ranges"] == {}
+
+    lhs = generate_doe(
+        kind="lhs",
+        factors={"x": [0.0, 1.0], "y": [10.0, 20.0]},
+        n_samples=2,
+        center_points=1,
+        replicates=2,
+        randomize=True,
+        seed=8,
+    )
+    assert lhs["summary"]["n_runs"] == 5
+
+    frac = generate_doe(kind="frac2", factors={"a": [-1, 1], "b": [-1, 1]}, randomize=False)
+    assert frac["summary"]["design_kind"] == DesignKind.FRACTIONAL_FACTORIAL_2LEVEL.value
+
+    with pytest.raises(ValidationError, match="Block column"):
+        randomize_runs([{"block": "a"}, {"run": 2}], block="block")
+    blocked = randomize_runs(
+        [{"block": "a", "run": 1}, {"block": "a", "run": 2}, {"block": "b", "run": 3}],
+        block="block",
+        seed=3,
+    )
+    assert [row["block"] for row in blocked] == ["a", "a", "b"]
+
     bad_json = tmp_path / "matrix-object.json"
     bad_json.write_text(json.dumps({"variant": "a"}), encoding="utf-8")
     study = make_study(tmp_path=tmp_path, study_id="bad-json-study")
     with pytest.raises(ValidationError, match="list of row objects"):
         build_design(study, {"kind": "custom_matrix", "matrix_path": str(bad_json)})
+
+    constrained = make_study(
+        tmp_path=tmp_path,
+        study_id="constraint-matrix-study",
+        constraints=(
+            Constraint(
+                constraint_id="must-be-b",
+                description="variant must be b",
+                expression="variant == 'b'",
+                severity=ConstraintSeverity.ERROR,
+            ),
+        ),
+    )
+    constrained_matrix = tmp_path / "constraint-matrix.json"
+    constrained_matrix.write_text(json.dumps([{"variant": "a"}]), encoding="utf-8")
+    constrained_conditions = build_design(
+        constrained,
+        {"kind": "custom_matrix", "matrix_path": str(constrained_matrix)},
+    )
+    assert constrained_conditions[0].admissible is False
+    assert constrained_conditions[0].constraint_messages == ["must-be-b: variant must be b"]
 
 
 def test_build_design_covers_lhs_bounds_and_fractional_validation_paths(tmp_path: Path) -> None:
@@ -387,6 +441,9 @@ def test_build_design_covers_lhs_bounds_and_fractional_validation_paths(tmp_path
             {"kind": "lhs", "options": {"n_samples": 1, "bounds": [0.0, 1.0]}},
         )
 
+    with pytest.raises(ValidationError, match=r"require DesignSpec\.n_samples"):
+        build_design(lhs_study, {"kind": "lhs"})
+
     non_numeric_lhs = make_study(
         tmp_path=tmp_path,
         study_id="lhs-nonnumeric-study",
@@ -415,3 +472,141 @@ def test_build_design_covers_lhs_bounds_and_fractional_validation_paths(tmp_path
     )
     with pytest.raises(ValidationError, match="exactly two levels per factor"):
         build_design(invalid_fractional, {"kind": "frac2"})
+
+    fractional_study = make_study(
+        tmp_path=tmp_path,
+        study_id="frac-design-study",
+        factors=(
+            Factor(
+                name="a",
+                description="A",
+                levels=(Level(name="low", value="low"), Level(name="high", value="high")),
+            ),
+            Factor(
+                name="b",
+                description="B",
+                levels=(Level(name="off", value=False), Level(name="on", value=True)),
+            ),
+        ),
+    )
+    fractional_conditions = build_design(
+        fractional_study,
+        {
+            "kind": "frac2",
+            "randomize": True,
+            "counterbalance": True,
+            "center_points": 1,
+            "block_randomization_key": "a",
+        },
+    )
+    assert len(fractional_conditions) == 5
+    assert {condition.metadata["design_kind"] for condition in fractional_conditions} == {
+        DesignKind.FRACTIONAL_FACTORIAL_2LEVEL.value
+    }
+
+    latin_mismatch = make_study(
+        tmp_path=tmp_path,
+        study_id="latin-mismatch-study",
+        factors=(
+            Factor(
+                name="row",
+                description="row",
+                levels=(Level("r1", "r1"), Level("r2", "r2")),
+            ),
+            Factor(
+                name="col",
+                description="col",
+                levels=(Level("c1", "c1"), Level("c2", "c2")),
+            ),
+            Factor(
+                name="treat",
+                description="treat",
+                levels=(Level("t1", "t1"),),
+            ),
+        ),
+    )
+    with pytest.raises(ValidationError, match="equal cardinality"):
+        build_design(
+            latin_mismatch,
+            {
+                "kind": "latin_square",
+                "options": {
+                    "row_factor": "row",
+                    "column_factor": "col",
+                    "treatment_factor": "treat",
+                },
+            },
+        )
+
+    with pytest.raises(ValidationError, match="Unsupported design kind"):
+        coerce_design_spec({"kind": "definitely-not-supported"})
+
+
+def test_optional_doe_backend_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional DOE backends should normalize success and missing-dependency failures."""
+
+    class FakeLatinHypercube:
+        def __init__(self, *, d: int, seed: int) -> None:
+            self.d = d
+            self.seed = seed
+
+        def random(self, *, n: int) -> list[list[float]]:
+            assert self.d == 2
+            assert self.seed == 11
+            return [[0.25, 0.75] for _ in range(n)]
+
+    def fake_scale(
+        samples: list[list[float]], lows: list[float], highs: list[float]
+    ) -> list[list[float]]:
+        return [
+            [
+                low + sample * (high - low)
+                for sample, low, high in zip(row, lows, highs, strict=True)
+            ]
+            for row in samples
+        ]
+
+    fake_qmc = SimpleNamespace(LatinHypercube=FakeLatinHypercube, scale=fake_scale)
+    monkeypatch.setattr(
+        designs_module,
+        "import_module",
+        lambda name: fake_qmc if name == "scipy.stats.qmc" else SimpleNamespace(),
+    )
+
+    scipy_rows = latin_hypercube(
+        2,
+        {"x": (0.0, 1.0), "y": (10.0, 20.0)},
+        seed=11,
+        backend="scipy",
+    )
+    assert scipy_rows == [{"x": 0.25, "y": 17.5}, {"x": 0.25, "y": 17.5}]
+
+    with pytest.raises(ValidationError, match="high > low"):
+        latin_hypercube(2, {"x": (1.0, 1.0)}, backend="scipy")
+
+    fake_pydoe = SimpleNamespace(fracfact=lambda generator: [[-1.0, 1.0], [1.0, -1.0]])
+    monkeypatch.setattr(
+        designs_module,
+        "import_module",
+        lambda name: fake_pydoe if name == "pyDOE3" else SimpleNamespace(),
+    )
+    assert fractional_factorial_2level(["a", "b"], backend="pydoe3") == [
+        {"a": -1.0, "b": 1.0},
+        {"a": 1.0, "b": -1.0},
+    ]
+
+    six_factor_rows = fractional_factorial_2level(["a", "b", "c", "d", "e", "f"])
+    assert six_factor_rows[0]["e"] == six_factor_rows[0]["a"] * six_factor_rows[0]["c"]
+    assert six_factor_rows[0]["f"] == six_factor_rows[0]["b"] * six_factor_rows[0]["c"]
+
+    with pytest.raises(ValidationError, match="between 2 and 6 factors"):
+        fractional_factorial_2level(["a", "b", "c", "d", "e", "f", "g"], backend="pydoe3")
+
+    def raise_import_error(name: str) -> None:
+        raise ImportError(name)
+
+    monkeypatch.setattr(designs_module, "import_module", raise_import_error)
+    with pytest.raises(ValidationError, match="optional dependencies"):
+        latin_hypercube(2, {"x": (0.0, 1.0)}, backend="qmc")
+    with pytest.raises(ValidationError, match="optional dependencies"):
+        fractional_factorial_2level(["a", "b"], backend="pydoe")

--- a/tests/test_io_study_schemas_and_runners.py
+++ b/tests/test_io_study_schemas_and_runners.py
@@ -185,7 +185,10 @@ class _FakeStream:
 
 def test_io_modules_yaml_json_csv_sqlite(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """IO helpers should read/write canonical file formats and error when YAML missing."""
-    rows = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+    rows = [
+        {"a": 1, "b": "x", "metadata": {"source": "first"}},
+        {"a": 2, "b": "y", "metadata": {"source": "second"}},
+    ]
     csv_path = tmp_path / "table.csv"
     csv_io.write_csv(csv_path, rows)
     read_rows = csv_io.read_csv(csv_path)
@@ -202,8 +205,11 @@ def test_io_modules_yaml_json_csv_sqlite(tmp_path: Path, monkeypatch: pytest.Mon
     sqlite_path = tmp_path / "tables.sqlite"
     sqlite_io.mirror_tables_to_sqlite(sqlite_path, tables={"rows": rows, "empty": []})
     with sqlite3.connect(sqlite_path) as connection:
-        result = list(connection.execute("SELECT a, b FROM rows ORDER BY a"))
-    assert result == [("1", "x"), ("2", "y")]
+        result = list(connection.execute("SELECT a, b, metadata FROM rows ORDER BY a"))
+    assert result == [
+        ("1", "x", '{"source": "first"}'),
+        ("2", "y", '{"source": "second"}'),
+    ]
 
     monkeypatch.setattr(yaml_io, "yaml", None)
     with pytest.raises(RuntimeError):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -35,6 +35,7 @@ def test_public_exports_match_curated_api() -> None:
         "StrategyComparisonConfig",
         "Study",
         "UnivariateComparisonConfig",
+        "__version__",
         "agent_result",
         "build_agent_architecture_comparison_study",
         "build_bivariate_comparison_study",
@@ -63,3 +64,9 @@ def test_public_exports_match_curated_api() -> None:
         "validate_study",
         "write_markdown_report",
     ]
+
+
+def test_package_version_is_public() -> None:
+    """Expose installed distribution metadata through the package API."""
+    assert isinstance(drexp.__version__, str)
+    assert drexp.__version__


### PR DESCRIPTION
## Summary

- preserve focused coverage for analysis-adapter compatibility and DOE validation from #24
- retain the versioned artifact contract without adding a second schema framework
- expose package `__version__` consistently across the ecosystem
- fail clearly when explicitly requested analysis validation is unavailable
- document the shared VS Code example workflow and quality-signal contract
- test missing files, required keys, schema versions, study identity, and SQLite structured-value serialization explicitly
- require at least 95% line coverage and 100% of curated top-level exports in runnable examples
- bump the package from 0.2.0 to 0.2.1

## Release decisions

Issue #16 was closed as already complete on `main`: canonical exports carry schema versions, validate all six required artifacts, and fail clearly on drift.

Issue #2 was closed as not planned because `RecipeStudyConfig` already supports explicit factor and outcome overrides. Recipe-specific aliases would duplicate syntax without adding capability.

## Validation

- `make ci`
- 95.06% total line coverage on GitHub's Python 3.12 runner
- API in Examples: 55/55
- deterministic examples and documentation consistency checks
- warning-free Sphinx HTML build
- sdist and wheel pass `twine check`

## Release Safety

- GitHub Releases publish only when the release tag matches the package version.
- Manual workflow runs are build-only unless publishing is explicitly enabled from the matching tag.
- All publishing paths run `make release-check` before PyPI upload.
